### PR TITLE
fix python3-scipy cross-compilation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ This Yocto layer is also the continuation and extension of:
 * [meta-scipy](https://github.com/tuxable-ltd/meta-scipy)
 * [meta-scikit-learn](https://github.com/tuxable-ltd/meta-scikit-learn)
 
+Installation
+------------
+
+You will need to enable FORTRAN support by adding the following to your
+`local.conf` file if you want to cross-compile python3-scipy:
+
+    FORTRAN:forcevariable = ",fortran"
+    RUNTIMETARGET:append:pn-gcc-runtime = " libquadmath"
+
+If you're using a custom distribution, you can alternatively include the two
+above lines in your `distro.conf` file.
+

--- a/recipes-python/scipy/python3-scipy_1.13.0.bb
+++ b/recipes-python/scipy/python3-scipy_1.13.0.bb
@@ -48,3 +48,9 @@ export F90
 export F77 = "${TARGET_PREFIX}gfortran"
 
 BBCLASSEXTEND = "native nativesdk"
+
+do_configure:append:class-target() {
+	if ! grep -q "numpy-include-dir" "${WORKDIR}/meson.cross" ; then
+		sed -i "s,\[properties\],\[properties\]\nnumpy-include-dir = \'${RECIPE_SYSROOT}${PYTHON_SITEPACKAGES_DIR}/numpy/core/include/\' ,g" "${WORKDIR}/meson.cross"
+	fi
+}


### PR DESCRIPTION
When trying to cross-compile python3-scipy version 1.13.0 on Yocto Scarthgap I am getting the following error:

```
[660/1475] Linking target scipy/stats/_biasedurn.cpython-312-aarch64-linux-gnu.so
FAILED: scipy/stats/_biasedurn.cpython-312-aarch64-linux-gnu.so 
aarch64-poky-linux-g++ -mbranch-protection=standard -fstack-protector-strong -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot  -o scipy/stats/_biasedurn.cpython-312-aarch64-linux-gnu.so scipy/stats/_biasedurn.cpython-312-aarch64-linux-gnu.so.p/meson-generated__biasedurn.cpp.o scipy/stats/_biasedurn.cpython-312-aarch64-linux-gnu.so.p/biasedurn_fnchyppr.cpp.o scipy/stats/_biasedurn.cpython-312-aarch64-linux-gnu.so.p/biasedurn_impls.cpp.o scipy/stats/_biasedurn.cpython-312-aarch64-linux-gnu.so.p/biasedurn_stoc1.cpp.o scipy/stats/_biasedurn.cpython-312-aarch64-linux-gnu.so.p/biasedurn_stoc3.cpp.o scipy/stats/_biasedurn.cpython-312-aarch64-linux-gnu.so.p/biasedurn_wnchyppr.cpp.o -Wl,--as-needed -Wl,--allow-shlib-undefined -Wl,-O1 -shared -fPIC -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -fcanon-prefix-map -fmacro-prefix-map=/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/scipy-1.13.0=/usr/src/debug/python3-scipy/1.13.0 -fdebug-prefix-map=/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/scipy-1.13.0=/usr/src/debug/python3-scipy/1.13.0 -fmacro-prefix-map=/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/build=/usr/src/debug/python3-scipy/1.13.0 -fdebug-prefix-map=/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/build=/usr/src/debug/python3-scipy/1.13.0 -fdebug-prefix-map=/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot= -fmacro-prefix-map=/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot= -fdebug-prefix-map=/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native= -Wl,-z,relro,-z,now -Wl,--version-script=/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/scipy-1.13.0/scipy/_build_utils/link-version-pyinit.map -Wl,--start-group /home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/../../random/lib/libnpyrandom.a /home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/../lib/libnpymath.a -Wl,--end-group
/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/13.2.0/ld: /home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/../../random/lib/libnpyrandom.a(distributions.o): Relocations in generic ELF (EM: 62)
/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/13.2.0/ld: /home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/../../random/lib/libnpyrandom.a(distributions.o): Relocations in generic ELF (EM: 62)
/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/13.2.0/ld: /home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/../../random/lib/libnpyrandom.a(distributions.o): Relocations in generic ELF (EM: 62)
/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/13.2.0/ld: /home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/../../random/lib/libnpyrandom.a(distributions.o): Relocations in generic ELF (EM: 62)
/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/13.2.0/ld: /home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/../../random/lib/libnpyrandom.a(distributions.o): Relocations in generic ELF (EM: 62)
/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/13.2.0/ld: /home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/../../random/lib/libnpyrandom.a(distributions.o): Relocations in generic ELF (EM: 62)
/home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/13.2.0/ld: /home/xmarquiegui/Proyectos/ai21/solidrun/build_scarthgap/tmp/work/aarch64-poky-linux/python3-scipy/1.13.0/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/../../random/lib/libnpyrandom.a: error adding symbols: file in wrong format
collect2: error: ld returned 1 exit status
```

This commit fixes the mentioned compilation error.