### PR TITLE
python3-pytorch: Allow to build without meta-intel

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,6 +10,8 @@ BBFILES += " \
 BBFILES_DYNAMIC += " \
 	clang-layer:${LAYERDIR}/dynamic-layers/clang-layer/*/*/*.bb \
 	clang-layer:${LAYERDIR}/dynamic-layers/clang-layer/*/*/*.bbappend \
+	intel:${LAYERDIR}/dynamic-layers/intel/*/*/*.bb \
+	intel:${LAYERDIR}/dynamic-layers/intel/*/*/*.bbappend \
 "
 
 BBFILE_COLLECTIONS += "meta-python-ai"

--- a/dynamic-layers/intel/recipes-python/pytorch/pytorch_%.bbappend
+++ b/dynamic-layers/intel/recipes-python/pytorch/pytorch_%.bbappend
@@ -1,0 +1,11 @@
+DEPENDS:append:x86-64 = " intel-oneapi-mkl intel-oneapi-dpcpp-cpp onednn"
+RDEPENDS:append:x86-64 = " intel-oneapi-mkl intel-oneapi-dpcpp-cpp-runtime onednn"
+
+LDFLAGS:append:class-target:x86-64 = " -ldnnl"
+BUILD_LDFLAGS:append:class-target:x86-64 = " -ldnnl"
+
+EXTRA_OECMAKE_ARCH_FLAGS:append:x86-64 = "\
+-DBLAS=MKL \
+-DBLAS_MKLDNN=ON \
+-DUSE_MKLDNN_CBLAS=ON \
+-DBUILD_ONEDNN_GRAPH=ON"

--- a/recipes-python/pytorch/python3-pytorch_2.3.1.bb
+++ b/recipes-python/pytorch/python3-pytorch_2.3.1.bb
@@ -14,8 +14,7 @@ DEPENDS = " \
 "
 
 DEPENDS:append:class-target = " \
-	zstd-native intel-oneapi-mkl intel-oneapi-dpcpp-cpp \
-	onednn tbb glog gloo numactl opencv \
+	zstd-native tbb glog gloo numactl opencv \
 	opencl-headers virtual/opencl-icd \
 	shaderc spirv-tools mesa \
 	${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan-headers vulkan-loader', '', d)} \
@@ -231,12 +230,12 @@ BUILD_CFLAGS += " \
 	-Wno-error=uninitialized \
 "
 
-LDFLAGS:append:class-target = " -ldnnl"
-BUILD_LDFLAGS:append:class-target = " -ldnnl"
-
 # Leave these variables below un-indented.
 # The contents of EXTRA_OECMAKE is split in python code,
 # which expects a single space between pieces.
+
+EXTRA_OECMAKE_ARCH_FLAGS ?= "\
+-DBLAS=Eigen"
 
 EXTRA_OECMAKE = "\
 -DC_HAS_AVX_2_EXITCODE=0 -DC_HAS_AVX_2_EXITCODE__TRYRUN_OUTPUT='' \
@@ -250,10 +249,7 @@ EXTRA_OECMAKE = "\
 -DPYTHON_LIBRARY=${STAGING_DIR}/${libdir}/${PYTHON_DIR} \
 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR} \
 -DGLIBCXX_USE_CXX11_ABI=1 \
--DBLAS=MKL \
--DUSE_MKLDNN=ON \
--DUSE_MKLDNN_CBLAS=ON \
--DBUILD_ONEDNN_GRAPH=ON \
+${EXTRA_OECMAKE_ARCH_FLAGS} \
 -DUSE_ITT=OFF \
 -DUSE_CUDA=OFF \
 -DUSE_FFMPEG=OFF \
@@ -339,15 +335,14 @@ INSANE_SKIP:${PN} = "dev-so"
 
 RDEPENDS:${PN}:class-target = " \
 	sleef glslang gflags zstd \
-	intel-oneapi-mkl intel-oneapi-dpcpp-cpp-runtime \
-	onednn tbb glog numactl opencv \
+	tbb glog numactl opencv \
 	shaderc spirv-tools ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan-loader', '', d)} \
 	python3-numpy python3-typing-extensions \
 	python3-pyyaml python3-pybind11 \
 	python3-sympy python3-six python3-onnx \
 "
 
-INSANE_SKIP:${PN} = "dev-so"
+INSANE_SKIP:${PN} = "dev-so already-stripped"
 SKIP_FILEDEPS:${PN} = '1'
 
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
Moved meta-intel and Intel specific details into a bbappend in dynamic-layers/intel.

Use -DBLAS=Eigen as default. It works with aarch64 among others. This is also overridden in the meta-intel specific bbappend file.

@Anuj-S62 This is an alternative to your #5 Thanks for the idea!