### PR TITLE
openblas-native: failed to link -lgfortran

### DIFF
--- a/recipes-support/openblas/openblas_0.3.28.bb
+++ b/recipes-support/openblas/openblas_0.3.28.bb
@@ -77,6 +77,25 @@ do_compile () {
 		TARGET='${@map_arch(d.getVar('TARGET_ARCH', True), d)}'
 }
 
+do_compile:class-native () {
+        oe_runmake HOSTCC="${BUILD_CC}" \
+                CC="${TARGET_PREFIX}gcc ${TOOLCHAIN_OPTIONS} ${@map_extra_options(d.getVar('TARGET_ARCH', True), d)}" \
+                PREFIX=${exec_prefix} \
+                ONLY_CBLAS=1 \
+                CROSS=1 \
+                CROSS_SUFFIX=${HOST_PREFIX} \
+                NO_STATIC=1 \
+                ${@bb.utils.contains('PACKAGECONFIG', 'lapack', 'NO_LAPACK=0', 'NO_LAPACK=1', d)} \
+                ${@bb.utils.contains('PACKAGECONFIG', 'lapacke', 'NO_LAPACKE=0', 'NO_LAPACKE=1', d)} \
+                ${@bb.utils.contains('PACKAGECONFIG', 'cblas', 'NO_CBLAS=0', 'NO_CBLAS=1', d)} \
+                ${@bb.utils.contains('PACKAGECONFIG', 'affinity', 'NO_AFFINITY=0', 'NO_AFFINITY=1', d)} \
+                ${@bb.utils.contains('PACKAGECONFIG', 'openmp', 'USE_OPENMP=1', 'USE_OPENMP=0', d)} \
+                ${@bb.utils.contains('PACKAGECONFIG', 'dynarch', 'DYNAMIC_ARCH=1', 'DYNAMIC_ARCH=0', d)} \
+                BINARY='${@map_bits(d.getVar('TARGET_ARCH', True), d)}' \
+                TARGET='${@map_arch(d.getVar('TARGET_ARCH', True), d)}'
+}
+
+
 do_install() {
 	oe_runmake HOSTCC="${BUILD_CC}" \
 		CC="${TARGET_PREFIX}gcc ${TOOLCHAIN_OPTIONS}" \


### PR DESCRIPTION
Actually, already remove the gfortran native support in bb file. But when compile openblas-native still linking to gfortran, I found a varialbe called: ONLY_CBLAS can disable it in exports/Makefile in openblas src, so add it to native case.