### PR TITLE
conf/layer.conf: Remove unneeded BBMASK

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,8 +23,3 @@ LAYERSERIES_COMPAT_meta-python-ai = "styhead"
 
 LAYERDEPENDS_meta-python-ai = "core openembedded-layer meta-python clang-revival-layer"
 LAYERRECOMMENDS_meta-python-ai = "intel"
-
-# python3-pre-commit needs python3-virtualenv >= 20.10.0
-# The one from meta-python satisfies.
-# But meta-cloud-services/meta-openstack has 1.11.4. Exclude this version.
-BBMASK := "${@ 'python3-virtualenv_1\..*\.bb' if (d.getVar('BBMASK') is None or d.getVar('BBMASK') == '') else d.getVar('BBMASK') + '|python3-virtualenv_1\..*\.bb' }"


### PR DESCRIPTION
The immediate expansion of BBMASK in layer.conf, prevent usage of BBMASK like described in https://github.com/zboszor/meta-python-ai/issues/15

Secondary the BBMASK change is not relevant anymore. Tested with styhead branch using the following layers.

 - meta-clang
 - meta-clang-revival
 - meta-cloud-services
 - meta-erlang
 - meta-openembedded
 - meta-python-ai
 - meta-virtualization
 - poky

building python3-virtualenv result in version 20.26.5, not changed by meta-cloud-services/meta-openstack.

Also tested that python3-pre-commit builds as expected with the BBMASK removed.

Just cleanup the layer.conf by removeing the unneeded BBMASK.