### PR TITLE
conf/layer.conf: clang-revival-layer to recommends

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -21,5 +21,5 @@ BBFILE_PRIORITY_meta-python-ai = "8"
 LAYERVERSION_meta-python-ai = "1"
 LAYERSERIES_COMPAT_meta-python-ai = "styhead"
 
-LAYERDEPENDS_meta-python-ai = "core openembedded-layer meta-python clang-revival-layer"
-LAYERRECOMMENDS_meta-python-ai = "intel"
+LAYERDEPENDS_meta-python-ai = "core openembedded-layer meta-python"
+LAYERRECOMMENDS_meta-python-ai = "intel clang-revival-layer"


### PR DESCRIPTION
The clang depended recipe - python3-llvmlite is already located in a
dynamic-layers config based on meta-clang. Though as meta-clang-revival
depend on meta-clang, it is not used.

With the move to LAYERRECOMMNDS instead of LAYERDEPENDS, it is possible
to build components from meta-python-ai without including both
meta-clang-revival and meta-clang.

As the current version of python3-llvmlite depend on clang15 from
meta-clang-revival it could be considered to move it to a dynamic layer
for meta-clang-revival. Though as the python3-llvmlite is updated to a
clang version from meta-clang, it would move back and forth - so just
keep it in meta-clang.