### PR TITLE
fix: Makefile openblas missing cblas.h

### DIFF
--- a/recipes-support/openblas/files/0001-fix-cblas-installation-ignores-the-value-of-NO_CBLAS.patch
+++ b/recipes-support/openblas/files/0001-fix-cblas-installation-ignores-the-value-of-NO_CBLAS.patch
@@ -1,0 +1,25 @@
+From 02b9272248c902740068555ea1f06fd19f9b726a Mon Sep 17 00:00:00 2001
+From: Xabier Marquiegui <xmarquiegui@ainguraiiot.com>
+Date: Tue, 12 Aug 2025 13:13:31 +0200
+Subject: [PATCH] fix: cblas installation ignores the value of NO_CBLAS
+
+---
+ Makefile.install | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.install b/Makefile.install
+index 6892efa51..5169ad3ff 100644
+--- a/Makefile.install
++++ b/Makefile.install
+@@ -68,7 +68,7 @@ install : 	lib.grd
+ 	@cat common_interface.h >> "$(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/f77blas.h"
+ 	@echo \#endif >> "$(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/f77blas.h"
+ 
+-ifndef NO_CBLAS
++ifneq ($(NO_CBLAS),1)
+ 	@echo Generating cblas.h in $(DESTDIR)$(OPENBLAS_INCLUDE_DIR)
+ 	@cp cblas.h cblas.tmp
+ ifdef SYMBOLPREFIX
+-- 
+2.39.5
+

--- a/recipes-support/openblas/openblas_0.3.28.bb
+++ b/recipes-support/openblas/openblas_0.3.28.bb
@@ -16,7 +16,10 @@ DEPENDS = "make libgfortran patchelf-native"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=5adf4792c949a00013ce25d476a2abc0"
 
-SRC_URI = "git://github.com/xianyi/OpenBLAS.git;protocol=https;branch=develop"
+SRC_URI = "\
+	file://0001-fix-cblas-installation-ignores-the-value-of-NO_CBLAS.patch \
+	git://github.com/xianyi/OpenBLAS.git;protocol=https;branch=develop \
+	"
 
 SRCREV = "5ef8b1964658f9cb6a6324a06f6a1a022609b0c5"
 


### PR DESCRIPTION
Compiling cblas using Makefiles instead of cmake results in make install skipping cblas.h because the Makefile is not verifying the value of the variable NO_CBLAS. This modification fixes that behabior.

This has already been proposed as an official change for [the original repository](https://github.com/OpenMathLib/OpenBLAS/pull/5421).