### PR TITLE
Handle both commas and quotes when replacing in __config__.py

### DIFF
--- a/recipes-python/scipy/python3-scipy_1.16.0.bb
+++ b/recipes-python/scipy/python3-scipy_1.16.0.bb
@@ -56,10 +56,10 @@ PKG_CONFIG_PATH:append = ":${RECIPE_SYSROOT}${PYTHON_SITEPACKAGES_DIR}/numpy/_co
 
 do_install:append:class-target () {
 	sed -i \
-		-e 's|, --sysroot=[^"]*||g' \
-		-e 's|, -ffile-prefix-map=[^,]*||g' \
-		-e 's|, -fdebug-prefix-map=[^,]*||g' \
-		-e 's|, -fmacro-prefix-map=[^,]*||g' \
+		-e 's|, --sysroot=[^,"]*||g' \
+		-e 's|, -ffile-prefix-map=[^,"]*||g' \
+		-e 's|, -fdebug-prefix-map=[^,"]*||g' \
+		-e 's|, -fmacro-prefix-map=[^,"]*||g' \
 		-e 's|nativepython3|python3|g' \
 		-e 's|r"${STAGING_DIR_NATIVE}|r"|g' \
 		-e 's|r"${STAGING_DIR_TARGET}|r"|g' \


### PR DESCRIPTION
First of all, I'd like to thank you for creating and maintaining this repository! Now let's move on to the problem :) When I try to use the python3-scipy package, the build succeeds, but when I try to import it, I get the following error:
```
  File "/usr/lib/python3.13/site-packages/scipy/__init__.py", line 51, in <module> 
    from scipy.__config__ import show as show_config
  File "/usr/lib/python3.13/site-packages/scipy/__config__.py", line 34
    "linker args": r"-Wl,-O1, -Wl,--hash-style=gnu, -Wl,--as-needed, -fcanon-prefix-map,

SyntaxError: unterminated string literal (detected at line 34) 
```
After a little research into the problem, it turned out that when deleting invalid paths for the target system, the closing quote is also erased. This happened because this quote was processed only for --sysroot=, in my case this argument is missing:
<img width="1197" height="566" alt="image" src="https://github.com/user-attachments/assets/0bd0ae60-30da-4aca-8851-366ca51bc288" />
The solution to this problem is to handle both commas and quotes for all regular expressions that work up to a certain character.
