### PR TITLE
python3-fsspec: 2025.5.1 -> 2025.12.0

### DIFF
--- a/recipes-python/fsspec/python3-fsspec_2025.12.0.bbappend
+++ b/recipes-python/fsspec/python3-fsspec_2025.12.0.bbappend
@@ -1,11 +1,6 @@
-PV = "2025.10.0"
-SRC_URI[sha256sum] = "b6789427626f068f9a83ca4e8a3cc050850b6c0f71f99ddb4f542b8266a26a59"
-
 RDEPENDS:${PN} += " \
 	python3-dask \
 	python3-distributed \
-	python3-requests \
-	python3-aiohttp \
 	python3-paramiko \
 	python3-s3fs \
 	python3-libarchive-c \


### PR DESCRIPTION
Current version in meta-python is 2025.12.0

Removed RDEPENDS python3-requests and python3-aiohttp. They are in the bb file of meta-python

@zboszor Did did not tested it.  I needed this bitbake was failing to parse the meta-ros Yocto layer at master(yocto) and Rolling (ros2).