### PR TITLE
libaec: update SRC-URI

### DIFF
--- a/recipes-support/libaec/libaec_1.1.5.bb
+++ b/recipes-support/libaec/libaec_1.1.5.bb
@@ -8,7 +8,7 @@ inherit cmake
 
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=128305912d075b470880a190ed3e8c53"
 
-SRC_URI = "git://gitlab.dkrz.de/k202009/libaec.git;protocol=https;branch=master"
+SRC_URI = "git://gitlab.dkrz.de/dkrz-sw/libaec.git;protocol=https;branch=main"
 
 SRCREV = "d84ea9c83097a0806f73fc48b69ae7eb9a94525e"
 


### PR DESCRIPTION
The project has been moved as mentioned on their gitlab. Update SRC_URI accordingly. as the project has moved to a different location as mentioned on the gitlab