### PR TITLE
LICENSE: converted to new syntax

### DIFF
--- a/recipes-python/astunparse/python3-astunparse_1.6.3.bb
+++ b/recipes-python/astunparse/python3-astunparse_1.6.3.bb
@@ -1,5 +1,5 @@
 SUMMARY = "An AST unparser for Python"
-LICENSE = "BSD-3-Clause & Python-2.0"
+LICENSE = "BSD-3-Clause AND Python-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7a7c771110c28a37480b73d07ad6d2a1"
 
 PYPI_PACKAGE = "astunparse"

--- a/recipes-python/blobfile/python3-blobfile_3.2.0.bb
+++ b/recipes-python/blobfile/python3-blobfile_3.2.0.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Read GCS, ABS and local paths with the same interface, clone of tensorflow.io.gfile"
-LICENSE = "PD"
+LICENSE = "LicenseRef-PD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=906b3f5f542bca77cd5dd18ede693457"
 
 PYPI_PACKAGE = "blobfile"

--- a/recipes-python/cython-bbox/python3-cython-bbox_0.1.5.bb
+++ b/recipes-python/cython-bbox/python3-cython-bbox_0.1.5.bb
@@ -1,5 +1,5 @@
 SUMMARY = "cython_bbox is widely used in object detection tasks"
-LICENSE = "MIT & UCB & BSD-3-Clause "
+LICENSE = "BSD-3-Clause AND MIT AND LicenseRef-UCB"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a3510fe5e9cf1dc156b7ba1812974594"
 
 DEPENDS = "python3-cython-native python3-numpy-native"

--- a/recipes-python/llvmlite/python3-llvmlite_0.48.0.bb
+++ b/recipes-python/llvmlite/python3-llvmlite_0.48.0.bb
@@ -1,5 +1,5 @@
 SUMMARY = "lightweight wrapper around basic LLVM functionality"
-LICENSE = "BSD-2-Clause & Apache-2.0-with-LLVM-exception"
+LICENSE = "BSD-2-Clause AND Apache-2.0 WITH LLVM-exception"
 LIC_FILES_CHKSUM = " \
 	file://LICENSE;md5=57c7cdf8c8d2dcbc7528fe68e52b3a17 \
 	file://LICENSE.thirdparty;md5=6942af3a9e3217451aceefd9432a6398"

--- a/recipes-python/numba/python3-numba_0.66.0.bb
+++ b/recipes-python/numba/python3-numba_0.66.0.bb
@@ -1,5 +1,5 @@
 SUMMARY = "compiling Python code using LLVM"
-LICENSE = "BSD-2-Clause & BSD-3-Clause & MIT"
+LICENSE = "BSD-2-Clause AND BSD-3-Clause AND MIT"
 LIC_FILES_CHKSUM = " \
 	file://LICENSE;md5=d9bed34136e8491d5d792c7efc17f10c \
 	file://LICENSES.third-party;md5=b5c6e034c796a55e98027b6bd95e1a56 \

--- a/recipes-python/onnx/python3-ml-dtypes_0.5.4.bb
+++ b/recipes-python/onnx/python3-ml-dtypes_0.5.4.bb
@@ -1,6 +1,6 @@
 SUMMARY = "ml_dtypes is a stand-alone implementation of several NumPy dtype extensions used in machine learning."
 DESCRIPTION = "ml_dtypes is a stand-alone implementation of several NumPy dtype extensions used in machine learning."
-LICENSE = "Apache-2.0 & MPL-2.0"
+LICENSE = "Apache-2.0 AND MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
                     file://LICENSE.eigen;md5=f75d2927d3c1ed2414ef72048f5ad640"
 

--- a/recipes-python/patchelf/python3-patchelf_0.17.2.4.bb
+++ b/recipes-python/patchelf/python3-patchelf_0.17.2.4.bb
@@ -1,6 +1,6 @@
 # This is a dummy package needed by python3-meson-python
 SUMMARY = "A small utility to modify the dynamic linker and RPATH of ELF executables."
-LICENSE = "GPL-3.0-or-later & Apache-2.0"
+LICENSE = "Apache-2.0 AND GPL-3.0-or-later"
 LIC_FILES_CHKSUM = " \
     file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
     file://COPYING;md5=d32239bcb673463ab874e80d47fae504 \

--- a/recipes-python/scikit-image/python3-scikit-image_0.26.0.bb
+++ b/recipes-python/scikit-image/python3-scikit-image_0.26.0.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Image processing in Python"
-LICENSE = "BSD-2-Clause & BSD-3-Clause & MIT"
+LICENSE = "BSD-2-Clause AND BSD-3-Clause AND MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=5b1729326cc368efafba32389bb032e5"
 
 DEPENDS = "python3-numpy-native python3-pythran-native python3-lazy-loader-native"

--- a/recipes-python/scipy/python3-scipy_1.17.1.bb
+++ b/recipes-python/scipy/python3-scipy_1.17.1.bb
@@ -1,6 +1,6 @@
 SUMMARY = "SciPy: Scientific Library for Python"
 HOMEPAGE = "https://www.scipy.org"
-LICENSE = "BSD-3-Clause & BSD-2-Clause & MIT & BSL-1.0 & Qhull & BSD-3-Clause-LBNL & Apache-2.0-with-LLVM-exception"
+LICENSE = "BSD-2-Clause AND BSD-3-Clause AND BSD-3-Clause-LBNL AND BSL-1.0 AND MIT AND Qhull AND Apache-2.0 WITH LLVM-exception"
 LIC_FILES_CHKSUM = " \
 	file://LICENSE.txt;md5=6506a2e1578b1a1161d9bda0b896c647 \
 	file://LICENSES_bundled.txt;md5=7bb7625ea6d801cd9de63572db6f0aa2 \


### PR DESCRIPTION
Converted with 'openembedded-core/scripts/contrib/convert-spdx-licenses.py'

needed for the current master of Yocto/OpenEmbedded