### PR TITLE
Update numba to release 0.60.0

### DIFF
--- a/dynamic-layers/clang-layer/recipes-python/numba/python3-numba_0.60.0.bb
+++ b/dynamic-layers/clang-layer/recipes-python/numba/python3-numba_0.60.0.bb
@@ -6,15 +6,11 @@ DEPENDS = "llvm-native llvm python3-numpy-native"
 
 PYPI_PACKAGE = "numba"
 
-PYPI_SEMVER_SUFFIX = "rc1"
-PYPI_ARCHIVE_NAME = "${PYPI_PACKAGE}-${PV}${PYPI_SEMVER_SUFFIX}.${PYPI_PACKAGE_EXT}"
-PR = "${@ 'r1' if d.getVar('PYPI_SEMVER_SUFFIX') == '' else 'r0.'+d.getVar('PYPI_SEMVER_SUFFIX') }"
-
-S:append = "${PYPI_SEMVER_SUFFIX}"
+PYPI_ARCHIVE_NAME = "${PYPI_PACKAGE}-${PV}.${PYPI_PACKAGE_EXT}"
 
 inherit pypi cmake setuptools3
 
-SRC_URI[sha256sum] = "47e9e4958c9a2226a4a1dd86a449dad95341fdef156915b29ef7d36cb58d3544"
+SRC_URI[sha256sum] = "5df6158e5584eece5fc83294b949fd30b9f1125df7708862205217e068aabf16"
 
 SRC_URI += "file://reduce-numpy-build-requirements.patch"
 


### PR DESCRIPTION
Previous version was 0.60.0rc1
I have found no major issue in rc1 but i guess it is better to use the released version.