### PR TITLE
Fix missing redepends for astunparse, beniget, contourpy & pythran

### DIFF
--- a/recipes-python/astunparse/python3-astunparse_1.6.3.bb
+++ b/recipes-python/astunparse/python3-astunparse_1.6.3.bb
@@ -7,4 +7,8 @@ PYPI_PACKAGE = "astunparse"
 inherit pypi setuptools3
 SRC_URI[sha256sum] = "5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872"
 
+RDEPENDS:${PN} = "\
+    python3-six \
+"
+
 BBCLASSEXTEND = "native"

--- a/recipes-python/beniget/python3-beniget_0.5.0.bb
+++ b/recipes-python/beniget/python3-beniget_0.5.0.bb
@@ -8,3 +8,7 @@ inherit pypi setuptools3
 SRC_URI[sha256sum] = "e7af11fa8ec7de3d3eb3d98b1e722d15d44017d8b35d8aa11d54f6719b312f22"
 
 BBCLASSEXTEND = "native"
+
+RDEPENDS:${PN} = "\
+    python3-gast \
+"

--- a/recipes-python/contourpy/python3-contourpy_1.3.3.bb
+++ b/recipes-python/contourpy/python3-contourpy_1.3.3.bb
@@ -15,3 +15,7 @@ export CONTOURPY_CXX11 = "1"
 
 PACKAGECONFIG ??= ""
 PACKAGECONFIG[bokeh] = ",,,python3-bokeh python3-selenium"
+
+RDEPENDS:${PN} = "\
+    python3-numpy \
+"

--- a/recipes-python/pythran/python3-pythran_0.18.1.bb
+++ b/recipes-python/pythran/python3-pythran_0.18.1.bb
@@ -13,6 +13,7 @@ SRC_URI += "file://updates-deps.patch"
 RDEPENDS:${PN} = " \
 	python3-beniget \
 	python3-gast \
+	python3-numpy \
 	python3-ply \
 "
 


### PR DESCRIPTION
Found some more missing runtime dependencies compared to pypi index :
https://pypi.org/pypi/astunparse/1.6.3/json
https://pypi.org/pypi/beniget/0.5.0/json
https://pypi.org/pypi/contourpy/1.3.3/json
https://pypi.org/pypi/pythran/0.18.1/json